### PR TITLE
Changes split on hardcoded "/" to os.sep for compatibility with Windows machines

### DIFF
--- a/flask_plugins/__init__.py
+++ b/flask_plugins/__init__.py
@@ -182,7 +182,7 @@ class PluginManager(object):
         self.app = app
 
         if base_app_folder is None:
-            base_app_folder = self.app.root_path.split("/")[-1]
+            base_app_folder = self.app.root_path.split(os.sep)[-1]
 
         self.plugin_folder = os.path.join(self.app.root_path, plugin_folder)
         self.base_plugin_package = ".".join(


### PR DESCRIPTION
The hardcoded `"/"` in the base_app_folder split was causing issues on Windows machines, where the seperator is `"\\"`. Using `os.sep` fixes this issue and ensures compatibility with Windows computers for Flask-Plugins (and the applications depending on it)
