### PR TITLE
Declare missing MarkupSafe and Werkzeug dependencies

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,12 +3,18 @@ Changelog
 
 Here you can see the full list of changes between each Flask-Plugins release.
 
-
 Version 1.x.x
 -------------
 
 Released on TBD.
 
+Version 1.6.2
+-------------
+
+Released on September 17th, 2025
+
+- Import `Markup` from `MarkupSafe` instead of `Jinja2`.
+- Declare missing `MarkupSafe` and `Werkzeug` dependencies.
 
 Version 1.6.1
 -------------
@@ -16,7 +22,6 @@ Version 1.6.1
 Released on January 26th, 2016
 
 - Do not call ``Plugin.setup()`` method in ``Plugin.enable()``.
-
 
 Version 1.6.0
 -------------
@@ -27,7 +32,6 @@ Released on January 26th, 2016
 - Adds `enable` and `disable` methods for plugins
 - BREAKING: The ``get_plugins_list()`` function got renamed to
   ``get_enabled_plugins()``.
-
 
 Previous Versions
 -----------------

--- a/flask_plugins/__init__.py
+++ b/flask_plugins/__init__.py
@@ -28,7 +28,7 @@ except ImportError:
 
 from ._compat import itervalues, iteritems, intern_method
 
-__version__ = "1.6.1"
+__version__ = "1.6.2"
 __author__ = "Peter Justin"
 
 

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,12 @@ setup(
     zip_safe=False,
     platforms='any',
     install_requires=[
-        'Flask>=0.6',
+        # first Flask dropping flask.Markup in favor of MarkupSafe
+        "Flask>=0.11",
+        # first MarkupSafe with Markup class
+        "MarkupSafe>=0.23",
+        # first Werkzeug with import_string & cached_property
+        "Werkzeug>=0.7",
     ],
     test_suite='nose.collector',
     tests_require=[


### PR DESCRIPTION
This patch updates `setup.py` to correctly declare all direct dependencies of Flask-Plugins and bumps the version to 1.6.2, preparing for the _decade anniversary release_ :birthday: on [PyPI](https://pypi.org/project/Flask-Plugins/). 

Flask-Plugins imports `Markup` from `MarkupSafe` and utilities from `Werkzeug`, but these were not listed in `install_requires`. Although Flask brings `Werkzeug` transitively, and Flask 0.11 (upgraded in this PR) also brings `MarkupSafe`, explicitly declaring them:
- ensures all direct dependencies are clearly documented,
- future-proofs against upstream changes in Flask or other packages, and
- makes dependency management more predictable for users and tools.

The following minimum versions are now explicitly required:
- `Flask>=0.11`: first Flask release to drop `flask.Markup` in favor of `MarkupSafe`.
- `MarkupSafe>=0.23`: first release providing the `Markup` class used in Flask-Plugins.
- `Werkzeug>=0.7`: first release including `import_string` and `cached_property`, both used in Flask-Plugins.

This change completes #25, which switched the `Markup` import from `Jinja2` to `MarkupSafe` but did not update `install_requires`. 

Resolves #24.

**Note:** Accepting this PR alone is not sufficient to make either fix available to users; a new PyPI release will be required — the first in almost a decade since version [1.6.1](https://pypi.org/project/Flask-Plugins/1.6.1/) from January 2016! As this repository does not appear to have automated workflow for publishing, I hope @sh4nks can do it manually. :pray: 