### PR TITLE
Modernize project for PyPI release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,99 @@
+name: CI / Build & Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  release:
+    types: [published]
+
+jobs:
+  # Run tests on multiple Python versions
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8, 3.9, 3.10, 3.11, 3.12]
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
+
+      - name: Install dev dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Run tests
+        run: pytest
+
+  # Build wheel + source distribution after tests pass
+  build:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.10
+
+      - name: Upgrade pip and install build
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+
+      - name: Build package
+        run: python -m build
+
+  # Publish to PyPI automatically on GitHub release
+  publish:
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.10
+
+      - name: Install Twine
+        run: pip install --upgrade twine
+
+      - name: Publish to PyPI
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: twine upload dist/*
+
+  # Publish to TestPyPI for dry-run testing
+  publish-test:
+    if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags/test-')
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.10
+
+      - name: Install Twine
+        run: pip install --upgrade twine
+
+      - name: Publish to TestPyPI
+        env:
+          TWINE_USERNAME: ${{ secrets.TESTPYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.TESTPYPI_PASSWORD }}
+        run: twine upload --repository testpypi dist/*

--- a/.gitignore
+++ b/.gitignore
@@ -47,5 +47,6 @@ flaskbb/configs/development.py
 
 *.rdb
 .coverage
-.tox/
 DISABLED
+
+dist/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
+include README.md
+include LICENSE
 recursive-include tests *.py
-include README.md LICENSE tox.ini

--- a/Makefile
+++ b/Makefile
@@ -1,31 +1,32 @@
-.PHONY: clean
+.PHONY: clean help sdist release release-test develop test
 
 help:
-	    @echo "  clean       remove unwanted stuff"
-	    @echo "  release     package and upload a release"
-	    @echo "  develop     make a development package"
-	    @echo "  sdist       package"
-	    @echo "  test        run the tests"
+	@echo "  clean           remove unwanted files"
+	@echo "  sdist           build source distribution"
+	@echo "  release         build and upload to PyPI"
+	@echo "  release-test    build and upload to TestPyPI"
+	@echo "  develop         install package in editable mode"
+	@echo "  test            run tests with pytest"
 
 clean:
-	    find . -name '*.pyc' -exec rm -f {} +
-	    find . -name '*.pyo' -exec rm -f {} +
-	    find . -name '*~' -exec rm -f {} +
-	    find . -name '.DS_Store' -exec rm -f {} +
-	    find . -name '__pycache__' -exec rm -rf {} +
-	    find . -name '.coverage' -exec rm -rf {} +
-
-release: register
-	    python setup.py sdist upload
-
-register:
-	    python setup.py register
+	find . -name '*.pyc' -exec rm -f {} +
+	find . -name '*.pyo' -exec rm -f {} +
+	find . -name '*~' -exec rm -f {} +
+	find . -name '.DS_Store' -exec rm -f {} +
+	find . -name '__pycache__' -exec rm -rf {} +
+	find . -name '.coverage' -exec rm -rf {} +
 
 sdist:
-	    python setup.py sdist
+	python -m build --sdist
+
+release: sdist
+	twine upload dist/*
+
+release-test: sdist
+	twine upload --repository testpypi dist/*
 
 develop:
-	    python setup.py develop
+	pip install -e .
 
 test:
-	    nosetests --cover-package=flask_plugins --with-coverage
+	pytest

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,0 @@
-Flask
-nose
-coverage
-coveralls

--- a/flask_plugins/__init__.py
+++ b/flask_plugins/__init__.py
@@ -19,12 +19,16 @@ from werkzeug.utils import cached_property, import_string
 from markupsafe import Markup
 from flask import json
 # Find the stack on which we want to store the database connection.
-# Starting with Flask 0.9, the _app_ctx_stack is the correct one,
-# before that we need to use the _request_ctx_stack.
 try:
+    # Flask >=0.9, <2.0
     from flask import _app_ctx_stack as stack
 except ImportError:
-    from flask import _request_ctx_stack as stack
+    try:
+        # Very old Flask (<0.9)
+        from flask import _request_ctx_stack as stack
+    except ImportError:
+        # Flask >=2.0: no private stacks, use g as a fallback
+        from flask import g as stack
 
 from ._compat import itervalues, iteritems, intern_method
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,57 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "Flask-Plugins"
+version = "1.6.2"
+description = "Create plugins for your Flask application"
+readme = "README.md"
+license = {text = "BSD"}
+authors = [
+    {name = "Peter Justin", email = "peter.justin@outlook.com"}
+]
+requires-python = ">=3.8"
+dependencies = [
+    "Flask>=2.0",
+    "MarkupSafe>=2.0",
+    "Werkzeug>=2.0",
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Framework :: Flask",
+    "Environment :: Web Environment",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: BSD License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest",
+    "coverage",
+    "Flask",
+]
+dev = [
+    "pytest",
+    "coverage",
+    "Flask",
+    "coveralls",
+    "build",
+]
+
+[tool.setuptools]
+packages = ["flask_plugins"]
+include-package-data = true
+zip-safe = false
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+addopts = "--maxfail=1 --disable-warnings -q"
+testpaths = ["tests"]

--- a/setup.py
+++ b/setup.py
@@ -1,97 +1,15 @@
-"""
-Flask-Plugins
--------------
+# This setup.py file is kept for legacy compatibility only.
+# All package metadata and build configuration are now defined in pyproject.toml.
+# You can still run commands like `python setup.py install`, but the preferred
+# way to build and install is:
+#
+#   python -m build
+#   pip install dist/<wheel>
+#
+# For more details, see:
+# https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/
 
-Flask-Plugins makes it possible, to create plugins for your
-application. In addition to the plugin system, it also provides a simple
-event system which can be used by plugins to extend your application without
-the need to modify your core code.
-
-
-And Easy to Setup
-`````````````````
-
-First of all, you have to install it:
-
-.. code:: bash
-
-    $ pip install flask-plugins
-
-and then you need to initialize it somewhere in your code.
-
-.. code:: python
-
-    from flask_plugins import PluginManager
-
-    plugin_manager = PluginManager(app)
-
-Want to use the factory pattern? No problem!
-
-.. code:: python
-
-    from flask_plugins import PluginManager
-
-    plugin_manager = PluginManager()
-    plugin_manager.init_app(app)
-
-Resources
-`````````
-
-* `source <https://github.com/sh4nks/flask-plugins>`_
-* `docs <https://flask-plugins.readthedocs.org/en/latest>`_
-* `issues <https://github.com/sh4nks/flask-plugins/issues>`_
-
-"""
 from setuptools import setup
-import re
-import ast
 
-
-def _get_version():
-    version_re = re.compile(r'__version__\s+=\s+(.*)')
-
-    with open('flask_plugins/__init__.py', 'rb') as fh:
-        version = ast.literal_eval(
-            version_re.search(fh.read().decode('utf-8')).group(1))
-
-    return str(version)
-
-
-setup(
-    name='Flask-Plugins',
-    version=_get_version(),
-    url='https://github.com/sh4nks/flask-plugins',
-    license='BSD',
-    author='Peter Justin',
-    author_email='peter.justin@outlook.com',
-    description='Create plugins for your Flask application',
-    long_description=__doc__,
-    packages=['flask_plugins'],
-    include_package_data=True,
-    zip_safe=False,
-    platforms='any',
-    install_requires=[
-        # first Flask dropping flask.Markup in favor of MarkupSafe
-        "Flask>=0.11",
-        # first MarkupSafe with Markup class
-        "MarkupSafe>=0.23",
-        # first Werkzeug with import_string & cached_property
-        "Werkzeug>=0.7",
-    ],
-    test_suite='nose.collector',
-    tests_require=[
-        'nose>=1.0',
-    ],
-    classifiers=[
-        'Development Status :: 4 - Beta',
-        'Framework :: Flask',
-        'Environment :: Web Environment',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: BSD License',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.4',
-        'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
-        'Topic :: Software Development :: Libraries :: Python Modules'
-    ]
-)
+if __name__ == "__main__":
+    setup()

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,0 @@
-[tox]
-envlist = py27,py34,pypy
-
-[testenv]
-deps=nose
-commands=nosetests tests


### PR DESCRIPTION
This PR modernizes the project for PyPI release in 2025, adding wheel support, `pyproject.toml`, and `pytest` integration. Existing tests remain legacy style and are **not yet runnable under pytest**.

### Changes

#### Modernization and PyPI readiness

- Added `pyproject.toml` with metadata, dependencies, and optional dev/test requirements for modern Python packaging.
- Replaced legacy `setup.py` with a minimal version for backward compatibility.
- Added GitHub Actions workflow for CI: runs tests, builds sdist/wheel, and uploads to PyPI on release tags.
- Updated `.gitignore` to exclude `dist/` and remove unused `.tox/` entry.
- Updated `Makefile` and `MANIFEST.in` for modern build, install, and test workflows.
- Removed `tox.ini` as testing is now configured via `pytest`.

#### Compatibility improvements

- Added support for Flask ≥2.0 by falling back to `flask.g` if private stacks are unavailable.
- Maintained backward compatibility with older Flask versions (<2.0) using the appropriate stack.

### ⚠️ Tests

- Existing tests remain **legacy nose/unittest style**.
- Currently, pytest **cannot discover or run these tests**.
- Full migration to pytest is recommended for proper CI test coverage.
- This PR focuses solely on **modernizing packaging and enabling PyPI release**.

### ⚠️ GitHub Actions workflow secrets

Requires the following GitHub secrets to publish:

Secret name | Purpose
-- | --
`PYPI_USERNAME` | PyPI username for uploading releases
`PYPI_PASSWORD` | PyPI API token (preferred) or password for uploading releases
`TESTPYPI_USERNAME` | TestPyPI username for dry-run uploads
`TESTPYPI_PASSWORD` | TestPyPI API token or password for dry-run uploads

- Without these secrets, the workflow can still **run tests and build distributions**, but publishing to PyPI/TestPyPI will fail.
- Add secrets via: **Settings** → **Secrets and variables** → **Actions** → **New repository secret**.

### How to release

- The GitHub Actions workflow is **triggered by creating a GitHub release**.
- Once a release tag is created, the workflow automatically:
  1. Builds the distribution (`sdist` and wheel)
  2. Runs tests (**after pytest migration**)
  3. Uploads to PyPI (or TestPyPI for dry runs)
- This is equivalent to running locally:
   ```
   make sdist
   make release-test
   make release
   ```

